### PR TITLE
Don't crash when missing ~/.ssh/known_hosts. Added init.sh to install de...

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# TODO: Make the script smart enough to know on which OS is running
+#       and use appropiate tools to install dependencies.
+#
+# For now it only works on CentOS.
+
+echo "Installing dependencies."
+
+yum install -y git expect nc
+
+echo "Generating SSH keys for Deployment."
+
+ssh-keygen -q -t rsa -f ~/.ssh/id_rsa_rdo -N "" -b 4096
+
+echo "Cloning Cloudbase openstack-rdo-scripts."
+
+git clone https://github.com/cloudbase/openstack-rdo-scripts
+
+cat <<EOF 
+
+Now you can deploy using the following command:
+
+~/openstack-rdo-scripts/configure-rdo-multi-node.sh havana ~/.ssh/id_rsa_rdo rdo-controller controller.ip.addr.ess rdo-network network.ip.addr.ess rdo-kvm kvm.ip.addr.ess rdo-hyperv hyperv.ip.addr.ess"
+
+EOF

--- a/utils.sh
+++ b/utils.sh
@@ -147,6 +147,12 @@ configure_ssh_pubkey_auth () {
 
     PUBKEYFILE=`mktemp -u /tmp/ssh_key_pub.XXXXXX`
 
+    # Don't fail if known_hosts missing
+
+    if [ ! -f ~/.ssh/known_hosts ] ; then
+      touch ~/.ssh/known_hosts
+    fi
+
     ssh-keygen -R $HOST
 
     wait_for_listening_port $HOST 22 $MAX_WAIT_SECONDS


### PR DESCRIPTION
On a pristine CentOS machine the configure script was crashing because there is no ~/.ssh/known_hosts file. Fixed that.

Also added an init.sh script to install dependencies, generate SSH keys and clone the repository. 

One can install dependencies and clone the repository by doing the following:

wget -O - https://raw.github.com/cloudbase/openstack-rdo-scripts/master/init.sh | bash
